### PR TITLE
Appveyor build script with artifact

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,16 @@
+image: Visual Studio 2017
+install:
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - git submodule --quiet update --init --recursive
+platform:
+  - x64
+configuration:
+  - Release
+build:
+  project: Solution\Menyoo.sln
+  verbosity: minimal
+after_build:
+  - 7z -tzip a MenyooSP.zip %APPVEYOR_BUILD_FOLDER%\Solution\source\_Build\bin\Release\* -xr!*.map -xr!Trash
+artifacts:
+  - path: MenyooSP.zip
+    name: Latest build of MenyooSP


### PR DESCRIPTION
Fixes https://github.com/MAFINS/MenyooSP/issues/36

Compiles and packages the `x64 Release` in to a single ZIP you'll be able to access [here](https://ci.appveyor.com/project/MAFINS/MenyooSP/build/artifacts) once AppVeyor is enabled on the repo. 

Excludes `Menyoo.map` and `Trash\` from being included, not sure if they're needed, was just matching what was included in the zip on GTA5 Mods.