### PR TITLE
Fix nativePush

### DIFF
--- a/Solution/source/Menyoo.vcxproj
+++ b/Solution/source/Menyoo.vcxproj
@@ -293,7 +293,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <Optimization>Disabled</Optimization>
+      <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;NativeTrainer_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/Solution/source/Natives/nativeCaller.h
+++ b/Solution/source/Natives/nativeCaller.h
@@ -10,7 +10,7 @@
 
 // Zorg93
 template <typename T>
-static inline void nativePush(const T& value)
+static inline void nativePush(T value)
 {
 	UINT64 val64 = 0;
 	//static_assert(sizeof(T) <= sizeof(UINT64), "error, value size > 64 bit");
@@ -25,14 +25,13 @@ static inline void nativePush(const T& value)
 //}
 
 template <typename T, typename... TArgs>
-static inline void nativePush(const T& value, const TArgs&... args)
+static inline void nativePush(T value, TArgs... args)
 {
-	nativePush(value);
-	nativePush(args...);
+	(nativePush(value), ...);
 }
 
 template <typename R, typename... TArgs>
-static inline R invoke(UINT64 hash, const TArgs&... args)
+static inline R invoke(UINT64 hash, TArgs... args)
 {
 	//static_assert(sizeof...(TArgs) <= 25, "Cannot push more than 25 Args to a native");
 	//static_assert(sizeof(R) <= 24, "Natives cannot return data types larger than 24 bytes");

--- a/Solution/source/Natives/nativeCaller.h
+++ b/Solution/source/Natives/nativeCaller.h
@@ -24,19 +24,13 @@ static inline void nativePush(T value)
 //	nativePush(value.c_str());
 //}
 
-template <typename T, typename... TArgs>
-static inline void nativePush(T value, TArgs... args)
-{
-	(nativePush(value), ...);
-}
-
 template <typename R, typename... TArgs>
 static inline R invoke(UINT64 hash, TArgs... args)
 {
 	//static_assert(sizeof...(TArgs) <= 25, "Cannot push more than 25 Args to a native");
 	//static_assert(sizeof(R) <= 24, "Natives cannot return data types larger than 24 bytes");
 	nativeInit(hash);
-	nativePush(args...);
+	(nativePush(args), ...);
 	return *reinterpret_cast<R *>(nativeCall());
 }
 


### PR DESCRIPTION
fixes #39 
Need someone to test if this works in-game when compiled with optimisation enabled.

Last time, there was an issue of GET_CURRENT_PED_WEAPON having unexpected behaviour so something like the "Teleport Gun" can be checked in-game.