### PR TITLE
Made the installation instructions clearer in the readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ Visual Studio 2017 required
 - I used v15.9.7
 
 ## Install
- Copy output .asi file along with the menyooStuff folder to the Grand Theft Auto V game directory, making sure asiloader and ScriptHookV are installed.
+ Copy the Menyoo.asi file along with the menyooStuff folder to the Grand Theft Auto V game directory.
+ **IMPORTANT:** Please make sure that you have asiloader and ScriptHookV installed and they are up to date.
+ Once you do all this you can enjoy the menu!
 
 ## Download
 Compiled binary material can be found at [releases](https://github.com/MAFINS/MenyooSP/releases).


### PR DESCRIPTION
This change is a fix for Issue #366. I noticed that some of the wording was confusing for installing the two main files. In the most recent release, the file is called `Menyoo.asi`, so I thought I would change the name to that so people wouldn't be confused. I believe I made it easier to understand the rest of the instructions as well.

-Dylan
(I'm new to contributing to projects so let me know if I did anything wrong.)