### PR TITLE
Bug fixes and QOL improvements

### DIFF
--- a/Solution/source/Scripting/GTAentity.cpp
+++ b/Solution/source/Scripting/GTAentity.cpp
@@ -370,7 +370,10 @@ int GTAentity::Alpha_get() const
 }
 void GTAentity::Alpha_set(int value)
 {
-	SET_ENTITY_ALPHA(this->mHandle, value, 0);
+	if(value == 255)
+		RESET_ENTITY_ALPHA(this->mHandle);
+	else
+		SET_ENTITY_ALPHA(this->mHandle, value, 0);
 }
 void GTAentity::ResetAlpha()
 {

--- a/Solution/source/Submenus/VehicleModShop.cpp
+++ b/Solution/source/Submenus/VehicleModShop.cpp
@@ -41,8 +41,8 @@ namespace sub
 	bool setwheel = false;
 	bool selectmod = false;
 	bool setMod = false;
-	int lastpaint, lastpearl, lastwheelcol;
-	bool menuselect = true, getpaint = true;
+	int lastpaint, lastpearl, lastr, lastg, lastb;
+	bool menuselect = true, getpaint = true, iscustompaint;
 
 	// Paints
 
@@ -420,11 +420,34 @@ namespace sub
 	{
 		INT currPaintInd;
 		currPaintInd = getpaintCarUsing_index(vehicle, ms_curr_paint_index);
-		
+
 		bool pressed = false;
 
 		if (_globalLSC_Customs)
 		{
+			if (getpaint)
+			{
+				lastpaint = getpaintCarUsing_index(Static_12, ms_curr_paint_index);
+				lastpearl = getpaintCarUsing_index(Static_12, 3);
+				if (ms_curr_paint_index == 1)
+				{
+					if (GET_IS_VEHICLE_PRIMARY_COLOUR_CUSTOM(Static_12))
+					{
+						iscustompaint = true;
+						GET_VEHICLE_CUSTOM_PRIMARY_COLOUR(Static_12, &lastr, &lastg, &lastb);
+					}
+				}
+				if (ms_curr_paint_index == 2)
+				{
+					if (GET_IS_VEHICLE_SECONDARY_COLOUR_CUSTOM(Static_12))
+					{
+						iscustompaint = true;
+						GET_VEHICLE_CUSTOM_SECONDARY_COLOUR(Static_12, &lastr, &lastg, &lastb);
+					}
+				}
+				getpaint = false;
+			}
+
 			std::vector<NamedVehiclePaint> THISMENUPAINT
 			{
 
@@ -473,10 +496,8 @@ namespace sub
 			{
 				getpaint = true;
 				menuselect = false;
-				lastpaint = getpaintCarUsing_index(vehicle, ms_curr_paint_index);
-				lastpearl = getpaintCarUsing_index(vehicle, 3);
-				if (IS_ENTITY_A_VEHICLE(vehicle) || ms_curr_paint_index == 10 || ms_curr_paint_index == 11)
-					paintCarUsing_index(vehicle, ms_curr_paint_index, lastpaint, lastpearl);
+				//if (IS_ENTITY_A_VEHICLE(vehicle) || ms_curr_paint_index == 10 || ms_curr_paint_index == 11)
+					//paintCarUsing_index(vehicle, ms_curr_paint_index, lastpaint, lastpearl);
 				Menu::SetSub_previous();
 				WAIT(10);
 				return;
@@ -487,6 +508,13 @@ namespace sub
 				menuselect = false;
 				if (IS_ENTITY_A_VEHICLE(vehicle) || ms_curr_paint_index == 10 || ms_curr_paint_index == 11)
 					paintCarUsing_index(vehicle, ms_curr_paint_index, lastpaint, lastpearl);
+				if (iscustompaint)
+				{
+					if (ms_curr_paint_index == 1)
+						SET_VEHICLE_CUSTOM_PRIMARY_COLOUR(vehicle,lastr, lastg, lastb);
+					else if (ms_curr_paint_index == 2)
+						SET_VEHICLE_CUSTOM_SECONDARY_COLOUR(vehicle,lastr, lastg, lastb);
+				}
 			}
 		}
 		else
@@ -529,6 +557,7 @@ namespace sub
 			paintFade_plus = 0, paintFade_minus = 0,
 			dirtLevel_plus = 0, dirtLevel_minus = 0;
 		getpaint = true;
+		menuselect = true;
 
 		AddTitle("Paints");
 		AddMSPaintsPointOption_(Game::GetGXTEntry("CMOD_COL0_0", "Primary"), 1); // Primary CMOD_COL0_0
@@ -541,7 +570,7 @@ namespace sub
 		AddNumber("Paint Fade", paintFade, 2, null, paintFade_plus, paintFade_minus);
 		AddNumber("Dirt Level", dirtLevel, 2, null, dirtLevel_plus, dirtLevel_minus);
 
-		if (firsttime == true)
+		if (firsttime)
 		{
 			GetAllPaintIDs();
 		}
@@ -583,7 +612,9 @@ namespace sub
 			MSPaints_RIndex = 0,
 			MSPaints_RColour = 0,
 			MSPaints_primRGB = 0;
-
+		
+		menuselect = true;
+		
 		GTAvehicle vehicle = Static_12;
 
 		INT paintIndex;
@@ -618,15 +649,6 @@ namespace sub
 			break;
 		}
 
-		if (getpaint)
-		{
-			lastpaint = getpaintCarUsing_index(Static_12, ms_curr_paint_index);
-			lastpearl = getpaintCarUsing_index(Static_12, 3);
-			getpaint = false;
-			Game::Print::PrintBottomCentre("Getting Paint: Current Paint Index = " + std::to_string(ms_curr_paint_index) + ", last paint = " + std::to_string(lastpaint));
-		}
-
-		menuselect = true;
 		AddOption("Chrome", null, nullFunc, SUB::MSPAINTS2_CHROME, true, true); // CMOD_COL1_0
 		AddOption("Classic", null, nullFunc, SUB::MSPAINTS2_NORMAL, true, true); // CMOD_COL1_1
 		AddOption("Matte", null, nullFunc, SUB::MSPAINTS2_MATTE, true, true); // CMOD_COL1_5
@@ -654,11 +676,14 @@ namespace sub
 				Add_preset_colour_options_previews(ms_curr_paint_index == 1 ? vehicle.CustomPrimaryColour_get() : ms_curr_paint_index == 2 ? vehicle.CustomSecondaryColour_get() : RgbS(0, 0, 0));
 		}
 
+		Game::Print::PrintBottomCentre("lastpaint = " + std::to_string(lastpaint) + ", ms_curr_paint_index = " + std::to_string(ms_curr_paint_index));
+
 		if (MSPaints_RIndex) {
 			if (vehicle.IsVehicle())
 			{
 				int randindex = rand() % paintIndex_maxValue;
 				paintCarUsing_index(Static_12, ms_curr_paint_index, randindex, -1);
+				getpaint = true;
 			}
 			return;
 		}
@@ -673,6 +698,7 @@ namespace sub
 					vehicle.CustomPrimaryColour_set(randr, randg, randb);
 				else if (ms_curr_paint_index == 2)
 					vehicle.CustomSecondaryColour_set(randr, randg, randb);
+				getpaint = true;
 			}
 			return;
 		}
@@ -1265,7 +1291,7 @@ namespace sub
 
 	// ModShop
 
-	
+
 
 	void ModShop_()
 	{
@@ -2093,7 +2119,7 @@ namespace sub
 				bool pressed = false;
 				AddTickol(get_mod_text_label(vehicle, modType, i, true), lastMod == i, pressed, pressed,
 					IS_THIS_MODEL_A_BIKE(GET_ENTITY_MODEL(vehicle)) ? TICKOL::BIKETHING : TICKOL::CARTHING, TICKOL::NONE, false);
-				if(setMod)
+				if (setMod)
 					SET_VEHICLE_MOD(vehicle, modType, *Menu::currentopATM - 2, GET_VEHICLE_MOD_VARIATION(vehicle, modType));
 				if (pressed)
 				{
@@ -2429,32 +2455,32 @@ namespace sub
 		//{
 			//if (ms_bit_bike_back) // Can probably remove this whole if statement with this exclusively working for bike wheels now - ijc
 			//{
-				bool bFrontPressed = false, bBackPressed = false;
-				AddOption("Front", bFrontPressed, nullFunc, SUB::MSWHEELS3); if (bFrontPressed)
-				{
-					chrtype = 0;
-					SET_VEHICLE_WHEEL_TYPE(Static_12, wtype);
-					ms_max_windices = GET_NUM_VEHICLE_MODS(Static_12, VehicleMod::FrontWheels);
-				}
-				AddOption("Rear", bBackPressed, nullFunc, SUB::MSWHEELS3); if (bBackPressed)
-				{
-					chrtype = 2;
-					SET_VEHICLE_WHEEL_TYPE(Static_12, wtype);
-					ms_max_windices = GET_NUM_VEHICLE_MODS(Static_12, VehicleMod::BackWheels);
-				}
-			//}
-			/*else // Not a bike.
+		bool bFrontPressed = false, bBackPressed = false;
+		AddOption("Front", bFrontPressed, nullFunc, SUB::MSWHEELS3); if (bFrontPressed)
+		{
+			chrtype = 0;
+			SET_VEHICLE_WHEEL_TYPE(Static_12, wtype);
+			ms_max_windices = GET_NUM_VEHICLE_MODS(Static_12, VehicleMod::FrontWheels);
+		}
+		AddOption("Rear", bBackPressed, nullFunc, SUB::MSWHEELS3); if (bBackPressed)
+		{
+			chrtype = 2;
+			SET_VEHICLE_WHEEL_TYPE(Static_12, wtype);
+			ms_max_windices = GET_NUM_VEHICLE_MODS(Static_12, VehicleMod::BackWheels);
+		}
+		//}
+		/*else // Not a bike.
+		{
+			bool bFrontPressed = false;
+			AddOption("Front & Rear", bFrontPressed, nullFunc, SUB::MSWHEELS3); if (true) //bypass this menu for all but bikes
 			{
-				bool bFrontPressed = false;
-				AddOption("Front & Rear", bFrontPressed, nullFunc, SUB::MSWHEELS3); if (true) //bypass this menu for all but bikes
-				{
-					chrtype = 0;
-					SET_VEHICLE_WHEEL_TYPE(Static_12, wtype);
-					ms_max_windices = GET_NUM_VEHICLE_MODS(Static_12, VehicleMod::FrontWheels);
-					Menu::SetSub_delayed = SUB::MSWHEELS3;
-					return;
-				}
-			}*/
+				chrtype = 0;
+				SET_VEHICLE_WHEEL_TYPE(Static_12, wtype);
+				ms_max_windices = GET_NUM_VEHICLE_MODS(Static_12, VehicleMod::FrontWheels);
+				Menu::SetSub_delayed = SUB::MSWHEELS3;
+				return;
+			}
+		}*/
 		//}
 		/*else // Unused - remove?
 		{

--- a/Solution/source/Submenus/VehicleModShop.cpp
+++ b/Solution/source/Submenus/VehicleModShop.cpp
@@ -184,6 +184,7 @@ namespace sub
 	{
 
 	};
+
 	INT paintIndex_maxValue = 0;
 
 	INT8 selectedpainttype;
@@ -596,7 +597,6 @@ namespace sub
 			else
 				Game::Print::PrintBottomCentre("~r~Error:~s~ Colours cannot be applied to stock wheels.");
 		}
-
 
 		if (paintFade_plus)
 		{
@@ -1049,7 +1049,8 @@ namespace sub
 		int ms_paints_rgb_r = 0,
 			ms_paints_rgb_g = 0,
 			ms_paints_rgb_b = 0,
-			ms_paints_rgb_a = -1;
+			ms_paints_rgb_a = -1,
+			ms_paints_finish{};
 		bool ms_paints_rgb_r_custom = 0,
 			ms_paints_rgb_r_plus = 0,
 			ms_paints_rgb_r_minus = 0,
@@ -1065,7 +1066,73 @@ namespace sub
 			ms_paints_hexinput = 0,
 			settings_hud_c_custom = 0,
 			settings_hud_c_plus = 0,
-			settings_hud_c_minus = 0;
+			settings_hud_c_minus = 0,
+			ms_paints_finish_plus = 0,
+			ms_paints_finish_minus = 0;
+
+		GTAvehicle vehicle = Static_12;
+
+		const std::vector<NamedVehiclePaint> PAINTS_FINISH
+		{
+			{ "Standard Metallic", 2, -1 },
+			{ "Dark Metallic", 0, -1 },
+			{ "Bright Metallic", 111, -1 },
+			{ "Matte", 12, -1 },
+			{ "Util", 15, -1 },
+			{ "Worn", 21, -1 },
+			{ "Brushed Metal", 117, -1 },
+			{ "Pure Chrome", 120, -1 },
+			{ "Coloured Chrome", 158, -1 },
+			{ "Satin", 159, -1 },
+		};
+
+		const std::vector<std::string> PAINTS_FINISH_NAMES
+		{
+			{ "Standard Metallic"},
+			{ "Dark Metallic"},
+			{ "Bright Metallic"},
+			{ "Matte"},
+			{ "Util"},
+			{ "Worn"},
+			{ "Brushed Metal"},
+			{ "Pure Chrome"},
+			{ "Coloured Chrome"},
+			{ "Satin"},
+		};
+
+		switch (getpaintCarUsing_index(Static_12, ms_curr_paint_index))
+		{
+			case 0:
+				ms_paints_finish = 1;
+				break;
+			case 111:
+				ms_paints_finish = 2;
+				break;
+			case 12:
+				ms_paints_finish = 3;
+				break;
+			case 15:
+				ms_paints_finish = 4;
+				break;
+			case 21:
+				ms_paints_finish = 5;
+				break;
+			case 117:
+				ms_paints_finish = 6;
+				break;
+			case 120:
+				ms_paints_finish = 7;
+				break;
+			case 158:
+				ms_paints_finish = 8;
+				break;
+			case 159:
+				ms_paints_finish = 9;
+				break;
+			case 2: default:
+				ms_paints_finish = 0;
+				break;
+		}
 
 		switch (bit_MSPaints_RGB_mode)
 		{
@@ -1080,8 +1147,8 @@ namespace sub
 		case 9: ms_paints_rgb_r = _globalSpawnVehicle_neonCol.R; ms_paints_rgb_g = _globalSpawnVehicle_neonCol.G; ms_paints_rgb_b = _globalSpawnVehicle_neonCol.B; break;
 		case 10: GET_HUD_COLOUR(Static_12, &ms_paints_rgb_r, &ms_paints_rgb_g, &ms_paints_rgb_b, &ms_paints_rgb_a); break;
 		}
-
 		AddTitle("Set Colour");
+		AddTexter("Paint Finish", ms_paints_finish, PAINTS_FINISH_NAMES, null , ms_paints_finish_plus, ms_paints_finish_minus);
 		AddNumber("Red", ms_paints_rgb_r, 0, ms_paints_rgb_r_custom, ms_paints_rgb_r_plus, ms_paints_rgb_r_minus);
 
 		switch (*Menu::currentopATM)
@@ -1306,8 +1373,56 @@ namespace sub
 			rgb_mode_set_carcol(Static_12, ms_paints_rgb_r, ms_paints_rgb_g, ms_paints_rgb_b, ms_paints_rgb_a);
 			return;
 		}
-
-
+		if (ms_paints_finish_plus)
+		{
+			if (ms_paints_finish < 9)
+				ms_paints_finish++;
+			else
+				ms_paints_finish = 0;
+			switch (ms_curr_paint_index)
+			{
+			case 1:	
+			{
+				auto& copy = vehicle.CustomPrimaryColour_get();
+				paintCarUsing_index(Static_12, ms_curr_paint_index, PAINTS_FINISH[ms_paints_finish].paint, -1);
+				vehicle.CustomPrimaryColour_set(copy.R, copy.G, copy.B);
+				break;
+			}
+			case 2:	
+			{
+				auto& copy = vehicle.CustomSecondaryColour_get();
+				paintCarUsing_index(Static_12, ms_curr_paint_index, PAINTS_FINISH[ms_paints_finish].paint, -1);
+				vehicle.CustomSecondaryColour_set(copy.R, copy.G, copy.B);
+				break;
+			}
+			}
+		}
+		if (ms_paints_finish_minus)
+		{
+			if (ms_paints_finish > 0)
+				ms_paints_finish--;
+			else
+				ms_paints_finish = 9;
+			switch (ms_curr_paint_index)
+			{
+			case 1:
+				if (GET_IS_VEHICLE_PRIMARY_COLOUR_CUSTOM(Static_12))
+				{
+					auto& copy = vehicle.CustomPrimaryColour_get();
+					paintCarUsing_index(Static_12, ms_curr_paint_index, PAINTS_FINISH[ms_paints_finish].paint, -1);
+					vehicle.CustomPrimaryColour_set(copy.R, copy.G, copy.B);
+				}
+				break;
+			case 2:
+				if (GET_IS_VEHICLE_SECONDARY_COLOUR_CUSTOM(Static_12))
+				{
+					auto& copy = vehicle.CustomSecondaryColour_get();
+					paintCarUsing_index(Static_12, ms_curr_paint_index, PAINTS_FINISH[ms_paints_finish].paint, -1);
+					vehicle.CustomSecondaryColour_set(copy.R, copy.G, copy.B);
+				}
+				break;
+			}
+		}
 	}
 
 	// vehicle - upgrades

--- a/Solution/source/Submenus/VehicleModShop.cpp
+++ b/Solution/source/Submenus/VehicleModShop.cpp
@@ -557,9 +557,10 @@ namespace sub
 		float dirtLevel = GET_VEHICLE_DIRT_LEVEL(Static_12);
 		float carvarcol = GET_VEHICLE_COLOUR_COMBINATION(Static_12)+1;
 		bool set_mspaints_index_4 = 0, set_mspaints_index_3 = 0,
+			set_mspaints_index_5 = 0, set_mspaints_index_6 = 0,
 			paintFade_plus = 0, paintFade_minus = 0,
 			dirtLevel_plus = 0, dirtLevel_minus = 0,
-			carvarcol_plus = 0, carvarcol_minus = 0;
+			carvarcol_plus = 0, carvarcol_minus = 0,
 		getpaint = true;
 		menuselect = true;
 
@@ -570,6 +571,9 @@ namespace sub
 		AddMSPaintsPointOption_(Game::GetGXTEntry("CMOD_COL0_1", "Secondary"), 2); // Secondary CMOD_COL0_1
 		AddOption(Game::GetGXTEntry("CMOD_COL1_6", "Pearlescent"), set_mspaints_index_3, nullFunc, SUB::MSPAINTS2_WHEELS, true, false); // Pearlescent CMOD_COL1_6
 		AddOption(Game::GetGXTEntry("CMOD_MOD_WHEM", "Wheels"), set_mspaints_index_4, nullFunc, -1, true);
+		AddOption("Interior Colour", set_mspaints_index_5, nullFunc, SUB::MSPAINTS2, true);
+		AddOption("Dashboard Colour", set_mspaints_index_6, nullFunc, SUB::MSPAINTS2,true);
+
 
 		AddBreak("---Collateral---");
 		AddNumber("Paint Fade", paintFade, 2, null, paintFade_plus, paintFade_minus);
@@ -592,10 +596,20 @@ namespace sub
 
 		if (set_mspaints_index_4) {
 			ms_curr_paint_index = 4;
-			if (GET_VEHICLE_MOD(Static_12, VehicleMod::FrontWheels) > -1)
-				Menu::SetSub_new(SUB::MSPAINTS2_WHEELS);
-			else
-				Game::Print::PrintBottomCentre("~r~Error:~s~ Colours cannot be applied to stock wheels.");
+			if (GET_VEHICLE_MOD(Static_12, VehicleMod::FrontWheels) < 0)
+				Game::Print::PrintBottomCentre("~b~Note:~s~ Colours cannot always be applied to stock wheels.");
+			Menu::SetSub_new(SUB::MSPAINTS2_WHEELS);
+			return;
+		}
+
+		if (set_mspaints_index_5) {
+			ms_curr_paint_index = 5;
+			return;
+		}
+
+		if (set_mspaints_index_6) {
+			ms_curr_paint_index = 6;
+			return;
 		}
 
 		if (paintFade_plus)
@@ -1100,8 +1114,10 @@ namespace sub
 			{ "Satin"},
 		};
 
-		switch (getpaintCarUsing_index(Static_12, ms_curr_paint_index))
+		if (bit_MSPaints_RGB_mode == 0 || bit_MSPaints_RGB_mode == 1)
 		{
+			switch (getpaintCarUsing_index(Static_12, ms_curr_paint_index))
+			{
 			case 0:
 				ms_paints_finish = 1;
 				break;
@@ -1132,6 +1148,7 @@ namespace sub
 			case 2: default:
 				ms_paints_finish = 0;
 				break;
+			}
 		}
 
 		switch (bit_MSPaints_RGB_mode)
@@ -1148,7 +1165,8 @@ namespace sub
 		case 10: GET_HUD_COLOUR(Static_12, &ms_paints_rgb_r, &ms_paints_rgb_g, &ms_paints_rgb_b, &ms_paints_rgb_a); break;
 		}
 		AddTitle("Set Colour");
-		AddTexter("Paint Finish", ms_paints_finish, PAINTS_FINISH_NAMES, null , ms_paints_finish_plus, ms_paints_finish_minus);
+		if(bit_MSPaints_RGB_mode == 0 || bit_MSPaints_RGB_mode == 1)
+			AddTexter("Paint Finish", ms_paints_finish, PAINTS_FINISH_NAMES, null , ms_paints_finish_plus, ms_paints_finish_minus);
 		AddNumber("Red", ms_paints_rgb_r, 0, ms_paints_rgb_r_custom, ms_paints_rgb_r_plus, ms_paints_rgb_r_minus);
 
 		switch (*Menu::currentopATM)

--- a/Solution/source/Submenus/VehicleModShop.cpp
+++ b/Solution/source/Submenus/VehicleModShop.cpp
@@ -492,6 +492,7 @@ namespace sub
 				if (IS_ENTITY_A_VEHICLE(vehicle) && menuselect || ms_curr_paint_index == 10 || ms_curr_paint_index == 11)
 					paintCarUsing_index(vehicle, ms_curr_paint_index, THISMENUPAINT[*Menu::currentopATM - 1].paint, THISMENUPAINT[*Menu::currentopATM - 1].pearl);
 			}
+
 			if (pressed)
 			{
 				getpaint = true;
@@ -553,11 +554,14 @@ namespace sub
 
 		float paintFade = _GET_VEHICLE_PAINT_FADE(Static_12);
 		float dirtLevel = GET_VEHICLE_DIRT_LEVEL(Static_12);
+		float carvarcol = GET_VEHICLE_COLOUR_COMBINATION(Static_12)+1;
 		bool set_mspaints_index_4 = 0, set_mspaints_index_3 = 0,
 			paintFade_plus = 0, paintFade_minus = 0,
-			dirtLevel_plus = 0, dirtLevel_minus = 0;
+			dirtLevel_plus = 0, dirtLevel_minus = 0,
+			carvarcol_plus = 0, carvarcol_minus = 0;
 		getpaint = true;
 		menuselect = true;
+
 
 		AddTitle("Paints");
 		AddMSPaintsPointOption_(Game::GetGXTEntry("CMOD_COL0_0", "Primary"), 1); // Primary CMOD_COL0_0
@@ -569,6 +573,9 @@ namespace sub
 		AddBreak("---Collateral---");
 		AddNumber("Paint Fade", paintFade, 2, null, paintFade_plus, paintFade_minus);
 		AddNumber("Dirt Level", dirtLevel, 2, null, dirtLevel_plus, dirtLevel_minus);
+		AddNumber("CarVariation Colours", carvarcol, 0, null, carvarcol_plus, carvarcol_minus);
+
+		Game::Print::PrintBottomCentre("Number of Vehicle Colours: " + std::to_string(GET_NUMBER_OF_VEHICLE_COLOURS(Static_12)));
 
 		if (firsttime)
 		{
@@ -593,18 +600,62 @@ namespace sub
 		}
 
 
-		if (paintFade_plus) {
-			if (paintFade < 1.0f) paintFade += 0.02f;
+		if (paintFade_plus)
+		{
+			if (paintFade < 1.0f) 
+				paintFade += 0.02f;
 			_SET_VEHICLE_PAINT_FADE(Static_12, paintFade);
 		}
-		if (paintFade_minus) {
-			if (paintFade > 0.02f) paintFade -= 0.02f;
+		if (paintFade_minus)
+		{
+			if (paintFade > 0.02f) 
+				paintFade -= 0.02f;
 			_SET_VEHICLE_PAINT_FADE(Static_12, paintFade);
 		}
 
-		if (dirtLevel_plus) { if (dirtLevel < 15.0f) { dirtLevel += 0.1f; SET_VEHICLE_DIRT_LEVEL(Static_12, dirtLevel); } }
-		if (dirtLevel_minus) { if (dirtLevel > 0.0f) { dirtLevel -= 0.1f; SET_VEHICLE_DIRT_LEVEL(Static_12, dirtLevel); } }
+		if (dirtLevel_plus)
+		{
+			if (dirtLevel < 15.0f)
+			{
+				dirtLevel += 0.1f;
+				SET_VEHICLE_DIRT_LEVEL(Static_12, dirtLevel);
+			}
+		}
+		if (dirtLevel_minus)
+		{
+			if (dirtLevel > 0.0f)
+			{
+				dirtLevel -= 0.1f;
+				SET_VEHICLE_DIRT_LEVEL(Static_12, dirtLevel);
+			}
+		}
 
+		if (carvarcol_plus)
+		{
+			if (carvarcol < GET_NUMBER_OF_VEHICLE_COLOURS(Static_12))
+			{
+				carvarcol += 1;
+				SET_VEHICLE_COLOUR_COMBINATION(Static_12, carvarcol-1);
+			}
+			else
+			{
+				carvarcol = 1;
+				SET_VEHICLE_COLOUR_COMBINATION(Static_12, carvarcol-1);
+			}
+		}
+		if (carvarcol_minus)
+		{
+			if (carvarcol > 1)
+			{
+				carvarcol -= 1;
+				SET_VEHICLE_COLOUR_COMBINATION(Static_12, carvarcol-1);
+			}
+			else
+			{
+				carvarcol = GET_NUMBER_OF_VEHICLE_COLOURS(Static_12);
+				SET_VEHICLE_COLOUR_COMBINATION(Static_12, carvarcol-1);
+			}
+		}
 	}
 	void MSPaints2_()
 	{

--- a/Solution/source/Submenus/VehicleModShop.cpp
+++ b/Solution/source/Submenus/VehicleModShop.cpp
@@ -341,6 +341,7 @@ namespace sub
 		{
 			ms_curr_paint_index = index;
 			extra_option_code = true;
+			getpaint = true;
 		}
 	}
 	INT getpaintCarUsing_index(Vehicle veh, INT partIndex_CustomK)
@@ -496,7 +497,9 @@ namespace sub
 
 			if (pressed)
 			{
-				getpaint = true;
+				//lastpaint = getpaintCarUsing_index(vehicle, ms_curr_paint_index);
+				//lastpearl = getpaintCarUsing_index(vehicle, 3);
+				//getpaint = true;
 				menuselect = false;
 				//if (IS_ENTITY_A_VEHICLE(vehicle) || ms_curr_paint_index == 10 || ms_curr_paint_index == 11)
 					//paintCarUsing_index(vehicle, ms_curr_paint_index, lastpaint, lastpearl);
@@ -506,7 +509,7 @@ namespace sub
 			}
 			if (MenuPressTimer::IsButtonTapped(MenuPressTimer::Button::Back))
 			{
-				getpaint = true;
+				//getpaint = true;
 				menuselect = false;
 				if (IS_ENTITY_A_VEHICLE(vehicle) || ms_curr_paint_index == 10 || ms_curr_paint_index == 11)
 					paintCarUsing_index(vehicle, ms_curr_paint_index, lastpaint, lastpearl);
@@ -560,12 +563,11 @@ namespace sub
 			set_mspaints_index_5 = 0, set_mspaints_index_6 = 0,
 			paintFade_plus = 0, paintFade_minus = 0,
 			dirtLevel_plus = 0, dirtLevel_minus = 0,
-			carvarcol_plus = 0, carvarcol_minus = 0,
+			carvarcol_plus = 0, carvarcol_minus = 0;
 		getpaint = true;
 		menuselect = true;
 
-
-		AddTitle("Paints");
+				AddTitle("Paints");
 		AddMSPaintsPointOption_(Game::GetGXTEntry("CMOD_COL0_0", "Primary"), 1); // Primary CMOD_COL0_0
 		 //if (_DOES_VEHICLE_HAVE_SECONDARY_COLOUR(Static_12))
 		AddMSPaintsPointOption_(Game::GetGXTEntry("CMOD_COL0_1", "Secondary"), 2); // Secondary CMOD_COL0_1

--- a/Solution/source/Submenus/VehicleSpawner.cpp
+++ b/Solution/source/Submenus/VehicleSpawner.cpp
@@ -80,7 +80,7 @@ namespace sub
 			{
 				float spacing1 = Model(GET_ENTITY_MODEL(oldcar)).Dim1().y + model.Dim2().y + 1.0f;
 				if(deleteOld)
-					Pos1 = GET_OFFSET_FROM_ENTITY_IN_WORLD_COORDS(oldcar, 0, 0, 2.0f);
+					Pos1 = GET_OFFSET_FROM_ENTITY_IN_WORLD_COORDS(oldcar, 0, 0, 0);
 				else
 					Pos1 = GET_OFFSET_FROM_ENTITY_IN_WORLD_COORDS(oldcar, 0, spacing1, 0);
 			}
@@ -121,7 +121,7 @@ namespace sub
 				}
 				SET_VEHICLE_ENGINE_ON(newcar, true, true);
 				SET_ENTITY_COLLISION(newcar, true, true);
-				SET_ENTITY_ALPHA(newcar, 255, false);
+				RESET_ENTITY_ALPHA(newcar);
 				if (warpIntoVehicle)
 				{
 					//if (Model(GET_ENTITY_MODEL(oldcar)).IsPlane()) CLEAR_PED_TASKS_IMMEDIATELY(ped); // mainPed

--- a/Solution/source/Submenus/VehicleSpawner.cpp
+++ b/Solution/source/Submenus/VehicleSpawner.cpp
@@ -168,7 +168,7 @@ namespace sub
 				if (warpIntoVehicle)
 					SET_PED_INTO_VEHICLE(ped.Handle(), newcar, (int)GTAvehicle(newcar).FirstFreeSeat(SEAT_DRIVER));
 					SET_ENTITY_COLLISION(newcar, true, true);
-					SET_ENTITY_ALPHA(newcar, 255, false);
+					RESET_ENTITY_ALPHA(newcar);
 			}
 			//SET_VEHICLE_NUMBER_PLATE_TEXT_INDEX(newcar, 5);
 			//SET_VEHICLE_NUMBER_PLATE_TEXT(newcar, "MENYOO");

--- a/Solution/source/macros.h
+++ b/Solution/source/macros.h
@@ -16,7 +16,7 @@
 #define _CRT_SECURE_NO_WARNINGS
 
 // version
-#define MENYOO_CURRENT_VER_ "1.7.1"
+#define MENYOO_CURRENT_VER_ "1.7.2"
 
 #define GAME_PLAYERCOUNT 30
 


### PR DESCRIPTION
Fixed a number of issues found within my code, and implemented fixes. One bug remains that I am struggling with that I could do with help on: 

if(pressed) 
Menu::SetSub_previous();

Instead of retaining the menu position from the last menu, either currentop or currentop_ar[currentsub_ar_index] resets to 1, taking users back to the top of the menyoo customs menu (Void ModShop_), rather than the menu option they just came from. 