### PR TITLE
Add persistence for vehicle spawner

### DIFF
--- a/Solution/source/Menu/MenuConfig.cpp
+++ b/Solution/source/Menu/MenuConfig.cpp
@@ -283,6 +283,7 @@ void MenuConfig::ConfigRead()
 	_globalSpawnVehicle_autoSit = ini.GetBoolValue(section_haxValues.c_str(), "vehicle_spawner_auto_sit", _globalSpawnVehicle_autoSit);
 	_globalSpawnVehicle_autoUpgrade = ini.GetBoolValue(section_haxValues.c_str(), "vehicle_spawner_auto_upgrade", _globalSpawnVehicle_autoUpgrade);
 	_globalSpawnVehicle_invincible = ini.GetBoolValue(section_haxValues.c_str(), "vehicle_spawner_invincible", _globalSpawnVehicle_invincible);
+	_globalSpawnVehicle_persistent = ini.GetBoolValue(section_haxValues.c_str(), "vehicle_spawner_persistent", _globalSpawnVehicle_persistent);
 	_globalSpawnVehicle_deleteOld = ini.GetBoolValue(section_haxValues.c_str(), "vehicle_spawner_delete_old", _globalSpawnVehicle_deleteOld);
 	_globalSpawnVehicle_neonToggle = ini.GetBoolValue(section_haxValues.c_str(), "vehicle_spawner_neons_on", _globalSpawnVehicle_neonToggle);
 	_globalSpawnVehicle_neonCol.R = ini.GetLongValue(section_haxValues.c_str(), "vehicle_spawner_neons_R", _globalSpawnVehicle_neonCol.R);
@@ -531,6 +532,7 @@ void MenuConfig::ConfigSave()
 	ini.SetBoolValue(section_haxValues.c_str(), "vehicle_spawner_auto_sit", _globalSpawnVehicle_autoSit);
 	ini.SetBoolValue(section_haxValues.c_str(), "vehicle_spawner_auto_upgrade", _globalSpawnVehicle_autoUpgrade);
 	ini.SetBoolValue(section_haxValues.c_str(), "vehicle_spawner_invincible", _globalSpawnVehicle_invincible);
+	ini.SetBoolValue(section_haxValues.c_str(), "vehicle_spawner_persistent", _globalSpawnVehicle_persistent);
 	ini.SetBoolValue(section_haxValues.c_str(), "vehicle_spawner_delete_old", _globalSpawnVehicle_deleteOld);
 	ini.SetBoolValue(section_haxValues.c_str(), "vehicle_spawner_neons_on", _globalSpawnVehicle_neonToggle);
 	ini.SetLongValue(section_haxValues.c_str(), "vehicle_spawner_neons_R", _globalSpawnVehicle_neonCol.R);

--- a/Solution/source/Menu/Routine.cpp
+++ b/Solution/source/Menu/Routine.cpp
@@ -218,7 +218,7 @@ std::string dict, dict2, dict3;
 std::string _globalSpawnVehicle_plateText = "MENYOO";
 INT8 _globalSpawnVehicle_plateType = 5, _globalSpawnVehicle_plateTexter_value = 0;
 RgbS _globalSpawnVehicle_neonCol = { 0, 255, 0 };
-bool _globalSpawnVehicle_autoSit = 1, _globalSpawnVehicle_autoUpgrade = 1, _globalSpawnVehicle_invincible = 1, _globalSpawnVehicle_deleteOld = 0, _globalSpawnVehicle_neonToggle = 0, _globalLSC_Customs = 1;
+bool _globalSpawnVehicle_autoSit = 1, _globalSpawnVehicle_autoUpgrade = 1, _globalSpawnVehicle_invincible = 1, _globalSpawnVehicle_persistent = 0, _globalSpawnVehicle_deleteOld = 0, _globalSpawnVehicle_neonToggle = 0, _globalLSC_Customs = 1;
 INT16 _globalSpawnVehicle_PrimCol = -3, _globalSpawnVehicle_SecCol = -3;
 bool _globalSpawnVehicle_drawBmps = true;
 

--- a/Solution/source/Menu/Routine.h
+++ b/Solution/source/Menu/Routine.h
@@ -90,7 +90,7 @@ extern std::string dict, dict2, dict3;
 extern std::string _globalSpawnVehicle_plateText;
 extern INT8 _globalSpawnVehicle_plateType, _globalSpawnVehicle_plateTexter_value;
 extern RgbS _globalSpawnVehicle_neonCol;
-extern bool _globalSpawnVehicle_autoSit, _globalSpawnVehicle_autoUpgrade, _globalSpawnVehicle_invincible, _globalSpawnVehicle_deleteOld, _globalSpawnVehicle_neonToggle, _globalLSC_Customs;
+extern bool _globalSpawnVehicle_autoSit, _globalSpawnVehicle_autoUpgrade, _globalSpawnVehicle_invincible, _globalSpawnVehicle_persistent, _globalSpawnVehicle_deleteOld, _globalSpawnVehicle_neonToggle, _globalLSC_Customs;
 extern INT16 _globalSpawnVehicle_PrimCol, _globalSpawnVehicle_SecCol;
 extern bool _globalSpawnVehicle_drawBmps;
 extern FLOAT _globalClearArea_radius;

--- a/Solution/source/Submenus/VehicleSpawner.cpp
+++ b/Solution/source/Submenus/VehicleSpawner.cpp
@@ -886,7 +886,7 @@ namespace sub
 					_globalSpawnVehicle_neonCol.R, _globalSpawnVehicle_neonCol.G, _globalSpawnVehicle_neonCol.B,
 					_globalSpawnVehicle_PrimCol, _globalSpawnVehicle_SecCol);
 
-				if (!NETWORK_IS_IN_SESSION())
+				if (!NETWORK_IS_IN_SESSION() && !_globalSpawnVehicle_persistent)
 					SET_VEHICLE_AS_NO_LONGER_NEEDED(&vehicle);
 			}
 		}
@@ -969,7 +969,7 @@ namespace sub
 					_globalSpawnVehicle_neonCol.R, _globalSpawnVehicle_neonCol.G, _globalSpawnVehicle_neonCol.B,
 					_globalSpawnVehicle_PrimCol, _globalSpawnVehicle_SecCol);
 
-				if (!NETWORK_IS_IN_SESSION())
+				if (!NETWORK_IS_IN_SESSION() && !_globalSpawnVehicle_persistent)
 					SET_VEHICLE_AS_NO_LONGER_NEEDED(&spawnedVehicle);
 			}
 			else Game::Print::PrintError_InvalidModel();
@@ -1004,6 +1004,7 @@ namespace sub
 		AddToggle("Auto-Sit In Vehicle", _globalSpawnVehicle_autoSit);
 		AddToggle("Spawn Pre-Upgraded", _globalSpawnVehicle_autoUpgrade);
 		AddToggle("Spawn Invincible", _globalSpawnVehicle_invincible);
+		AddToggle("Spawn Persistent", _globalSpawnVehicle_persistent);
 		AddOption("Primary Paint", set_mspaint_index_10, nullFunc, SUB::MSPAINTS2); // Primary Paint
 		AddOption("Secondary Paint", set_mspaint_index_11, nullFunc, SUB::MSPAINTS2); // Secondary Paint
 		AddBreak("---Neons---");
@@ -2000,7 +2001,7 @@ namespace sub
 				}
 				for (auto& e : vSpawnedAttachments)
 				{
-					e.e.Handle.NoLongerNeeded();
+					if (!_globalSpawnVehicle_persistent) e.e.Handle.NoLongerNeeded();
 				}
 			}
 

--- a/Solution/source/_Build/bin/Release/menyooStuff/menyooConfig.ini
+++ b/Solution/source/_Build/bin/Release/menyooStuff/menyooConfig.ini
@@ -102,6 +102,7 @@ vehicle_spawner_plate_type = 5
 vehicle_spawner_auto_sit = 1
 vehicle_spawner_auto_upgrade = 0
 vehicle_spawner_invincible = 1
+vehicle_spawner_persistent = 0
 vehicle_spawner_delete_old = 0
 vehicle_spawner_neons_on = 0
 vehicle_spawner_neons_R = 0


### PR DESCRIPTION
Adds global variable for Vehicle Spawner persistence (default false), adds toggle in Vehicle Spawner to enable/disable persistence, adjusts all spawn functions to allow spawned vehicles to be persistent should the user choose. Resolves #516 if merged.