### PR TITLE
Fix clothes menu endless scroll

### DIFF
--- a/Solution/source/Submenus/PedComponentChanger.cpp
+++ b/Solution/source/Submenus/PedComponentChanger.cpp
@@ -337,10 +337,10 @@ namespace sub
             || compon_texture_old != compon_texture_current
             || compon_palette_old != compon_palette_current)
         {
+        	//if (IS_PED_COMPONENT_VARIATION_VALID(Static_241, Static_12, compon_drawable_current, compon_texture_current))
+        	SET_PED_COMPONENT_VARIATION(Static_241, Static_12, compon_drawable_current, compon_texture_current, compon_palette_current);
             while (!HasPedSpecificDrawable(compon_drawable_current))
             {
-            	//if (IS_PED_COMPONENT_VARIATION_VALID(Static_241, Static_12, compon_drawable_current, compon_texture_current))
-            	SET_PED_COMPONENT_VARIATION(Static_241, Static_12, compon_drawable_current, compon_texture_current, compon_palette_current);
                 if (compon_plus)
                 {
                     if (compon_drawable_current < GET_NUMBER_OF_PED_DRAWABLE_VARIATIONS(Static_241, Static_12) - 1)
@@ -368,7 +368,7 @@ namespace sub
                         compon_texture_current = 0;
                     }
                 }
-                //SET_PED_COMPONENT_VARIATION(Static_241, Static_12, compon_drawable_current, compon_texture_current, compon_palette_current);
+                SET_PED_COMPONENT_VARIATION(Static_241, Static_12, compon_drawable_current, compon_texture_current, compon_palette_current);
             }
         }
     }

--- a/Solution/source/Submenus/PedComponentChanger.cpp
+++ b/Solution/source/Submenus/PedComponentChanger.cpp
@@ -333,16 +333,57 @@ namespace sub
 
 		}
 
-		if (compon_drawable_old != compon_drawable_current
-			|| compon_texture_old != compon_texture_current
-			|| compon_texture_old != compon_palette_current)
-		{
-			//if (IS_PED_COMPONENT_VARIATION_VALID(Static_241, Static_12, compon_drawable_current, compon_texture_current))
-			SET_PED_COMPONENT_VARIATION(Static_241, Static_12, compon_drawable_current, compon_texture_current, compon_palette_current);
-		}
-	}
-	void ComponentChangerProps_()
+        if (compon_drawable_old != compon_drawable_current
+            || compon_texture_old != compon_texture_current
             || compon_palette_old != compon_palette_current)
+        {
+            while (!HasPedSpecificDrawable(compon_drawable_current))
+            {
+            	//if (IS_PED_COMPONENT_VARIATION_VALID(Static_241, Static_12, compon_drawable_current, compon_texture_current))
+            	SET_PED_COMPONENT_VARIATION(Static_241, Static_12, compon_drawable_current, compon_texture_current, compon_palette_current);
+                if (compon_plus)
+                {
+                    if (compon_drawable_current < GET_NUMBER_OF_PED_DRAWABLE_VARIATIONS(Static_241, Static_12) - 1)
+                    {
+                        compon_drawable_current++;
+                        compon_texture_current = 0;
+                    }
+                    else
+                    {
+                        compon_drawable_current = 0;
+                        compon_texture_current = 0;
+                    }
+                }
+                else if (compon_minus)
+                {
+                    if (compon_drawable_current > -1)
+                    {
+                        compon_drawable_current--;
+                        compon_texture_current = 0;
+                        //Game::Print::PrintBottomLeft(oss_ << "compon_drawable_current prev " << compon_drawable_current << ".");
+                    }
+                    else
+                    {
+                        compon_drawable_current = GET_NUMBER_OF_PED_DRAWABLE_VARIATIONS(Static_241, Static_12) - 1;
+                        compon_texture_current = 0;
+                    }
+                }
+                //SET_PED_COMPONENT_VARIATION(Static_241, Static_12, compon_drawable_current, compon_texture_current, compon_palette_current);
+            }
+        }
+    }
+
+    bool HasPedSpecificDrawable(int compon_drawable_new)
+    {
+        bool correctComp = false;
+        int currentComp = GET_PED_DRAWABLE_VARIATION(Static_241, Static_12);
+        if (compon_drawable_new == currentComp)
+        {
+            correctComp = true;
+        }
+        return correctComp;
+    }
+    void ComponentChangerProps_()
 	{
 		GTAped thisPed = Static_241;
 

--- a/Solution/source/Submenus/PedComponentChanger.cpp
+++ b/Solution/source/Submenus/PedComponentChanger.cpp
@@ -375,13 +375,13 @@ namespace sub
 
     bool HasPedSpecificDrawable(int compon_drawable_new)
     {
-        bool correctComp = false;
-        int currentComp = GET_PED_DRAWABLE_VARIATION(Static_241, Static_12);
-        if (compon_drawable_new == currentComp)
+        bool compon_drawable_correct = false;
+        int compon_drawable_current = GET_PED_DRAWABLE_VARIATION(Static_241, Static_12);
+        if (compon_drawable_new == compon_drawable_current)
         {
-            correctComp = true;
+            compon_drawable_correct = true;
         }
-        return correctComp;
+        return compon_drawable_correct;
     }
     void ComponentChangerProps_()
 	{
@@ -501,8 +501,50 @@ namespace sub
 			if (prop_type_current == -1)
 				CLEAR_PED_PROP(ped.Handle(), propId, 0);
 			else
+			{
 				SET_PED_PROP_INDEX(ped.Handle(), propId, prop_type_current, prop_texture_current, NETWORK_IS_GAME_IN_PROGRESS(), 0);
+				while (!HasPedSpecificPropType(prop_type_current))
+				{
+					if (compon_plus)
+					{
+						if (prop_type_current < GET_NUMBER_OF_PED_PROP_DRAWABLE_VARIATIONS(Static_241, Static_12) - 1)
+						{
+							prop_type_current++;
+							prop_texture_current = 0;
+						}
+						else
+						{
+							prop_type_current = -1;
+							prop_texture_current = 0;
+						}
+					}
+					else if (compon_minus)
+					{
+						if (prop_type_current > -1)
+						{
+							prop_type_current--;
+							prop_texture_current = 0;
+						}
+						else
+						{
+							prop_type_current = GET_NUMBER_OF_PED_PROP_DRAWABLE_VARIATIONS(Static_241, Static_12) - 1;
+							prop_texture_current = 0;
+						}
+					}
+				SET_PED_PROP_INDEX(ped.Handle(), propId, prop_type_current, prop_texture_current, NETWORK_IS_GAME_IN_PROGRESS(), 0);
+				}
+			}
 		}
+	}
+	bool HasPedSpecificPropType(int prop_type_new)
+	{
+		bool prop_type_correct = false;
+		int prop_type_current = GET_PED_PROP_INDEX(Static_241, Static_12, 0);
+		if (prop_type_new == prop_type_current)
+		{
+			prop_type_correct = true;
+		}
+		return prop_type_correct;
 	}
 
 	// Decals - tattoos & badges

--- a/Solution/source/Submenus/PedComponentChanger.cpp
+++ b/Solution/source/Submenus/PedComponentChanger.cpp
@@ -342,6 +342,7 @@ namespace sub
 		}
 	}
 	void ComponentChangerProps_()
+            || compon_palette_old != compon_palette_current)
 	{
 		GTAped thisPed = Static_241;
 

--- a/Solution/source/Submenus/PedComponentChanger.h
+++ b/Solution/source/Submenus/PedComponentChanger.h
@@ -40,9 +40,10 @@ namespace sub
 
 	void ComponentChanger_();
 	void ComponentChanger2_();
+	bool HasPedSpecificDrawable(int compon_drawable_new);
 	void ComponentChangerProps_();
 	void ComponentChangerProps2_();
-	bool HasPedSpecificDrawable(int compon_drawable_new);
+	bool HasPedSpecificPropType(int prop_type_new);
 
 	// Decals - tattoos & badges
 

--- a/Solution/source/Submenus/PedComponentChanger.h
+++ b/Solution/source/Submenus/PedComponentChanger.h
@@ -42,6 +42,7 @@ namespace sub
 	void ComponentChanger2_();
 	void ComponentChangerProps_();
 	void ComponentChangerProps2_();
+	bool HasPedSpecificDrawable(int compon_drawable_new);
 
 	// Decals - tattoos & badges
 


### PR DESCRIPTION
Fixes: https://github.com/MAFINS/MenyooSP/issues/586 , https://github.com/MAFINS/MenyooSP/issues/544 , https://github.com/MAFINS/MenyooSP/issues/372
fixes the endless scroll for component & prop selection
because Rockstar added placeholder .ytd's to the compents and these placeholders can't be selected in the menu..